### PR TITLE
separate standard and third-party imports in dazo.py

### DIFF
--- a/mekus/dazo.py
+++ b/mekus/dazo.py
@@ -1,5 +1,6 @@
-import os
-import pyfiglet
+import os  # Standard library
+
+import pyfiglet  # Third-party library
 
 WIN = "win"
 LOSS = "loss"


### PR DESCRIPTION
I have separated standard and third-party imports in `dazo.py` for readability and style compliance.

Please review my changes and let me know if adjustments are needed. Thank you!